### PR TITLE
Multi containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-## cookies.txt
+# cookies.txt
 
 Firefox Add-on which exports all cookies to a Netscape HTTP Cookie File, as used by curl, wget, and youtube-dl, among others.
+
+## Multiple Containers
+The Add-on is able to export the cookies for each of the containers in Firefox. The cookies of the default container will be exported in ``cookies.txt``, the cookies of any other *named* container will be exported in ``cookies.*name-of-container*.txt``.
 
 ## Licence
 
 <a href="https://github.com/lennonhill/cookies-txt/blob/master/LICENSE">GPLv3</a>
-

--- a/background.js
+++ b/background.js
@@ -1,4 +1,3 @@
-
 function formatCookie(co) {
   return [
     [
@@ -15,22 +14,55 @@ function formatCookie(co) {
   ].join('\t');
 }
 
-function saveCookies(cookies) {
+async function getCookiesFilename(storeId) {
+  if (storeId == 'firefox-default') { 
+    return 'cookies.txt' 
+  } else {
+    let container;
+    try {
+      container = await browser.contextualIdentities.get(storeId); 
+    } catch (e) {
+      /* In case we can't get the name of the container, fallback on the storeId */
+      container = storeId
+    }
+    return 'cookies.' + container.name + '.txt'
+  }
+}
+
+async function saveCookies(cookies) {
   var header = [
     '# Netscape HTTP Cookie File\n',
     '# https://curl.haxx.se/rfc/cookie_spec.html\n',
     '# This is a generated file! Do not edit.\n\n'
   ];
   var body = cookies.map(formatCookie)
+  let storeId = cookies[0].storeId
   var blob = new Blob(header.concat(body), {type: 'text/plain'});
   var objectURL = URL.createObjectURL(blob);
-  browser.downloads.download({url: objectURL, filename: 'cookies.txt',
-    saveAs: true, conflictAction: 'overwrite'});
+  let cookiesFilename = await getCookiesFilename(storeId)
+  browser.downloads.download(
+    {
+      url: objectURL, 
+      filename: cookiesFilename,
+      saveAs: true, 
+      conflictAction: 'overwrite'
+    }
+  );
+}
+
+function getCookies(stores) {
+  for (var store of stores) {
+    console.log("Store: " + store.id)
+    var gettingAll = browser.cookies.getAll({
+        storeId: store.id
+    });
+    gettingAll.then(saveCookies);
+  }
 }
 
 function handleClick() {
-  var gettingAll = browser.cookies.getAll({});
-  gettingAll.then(saveCookies);
+  var gettingAllStores = browser.cookies.getAllCookieStores()
+  gettingAllStores.then(getCookies)
 }
 
 browser.browserAction.onClicked.addListener(handleClick);

--- a/manifest.json
+++ b/manifest.json
@@ -37,6 +37,7 @@
   "permissions": [
     "cookies",
     "downloads",
+    "contextualIdentities",
     "<all_urls>"
   ]
 }


### PR DESCRIPTION
I have adapted the ``cookies.txt`` code to be able to export the cookies stored in multiple containers. As there could be overlap between cookies from different containers, each container has a separate cookie file.

If the user does not user containers, the add-on is still exporting a single ``cookie.txt`` file.