### PR TITLE
Fix TypeError when there’s no cookie in store

### DIFF
--- a/background.js
+++ b/background.js
@@ -19,7 +19,6 @@ function formatCookie(co) {
  * @param {string} storeId ID of the cookie store to get cookies for.
  */
 async function getCookiesFilename(storeId) {
-  console.log('Store ID', storeId);
   if (storeId == 'firefox-default') {
     return 'cookies.txt'
   } else {
@@ -30,8 +29,6 @@ async function getCookiesFilename(storeId) {
       /* In case we can't get the name of the container, fallback on the storeId */
       containerName = storeId;
     }
-    console.log('Store ID', storeId);
-    console.log('Container name', containerName);
     return 'cookies.' + containerName + '.txt';
   }
 }

--- a/background.js
+++ b/background.js
@@ -38,7 +38,8 @@ async function getCookiesFilename(storeId) {
  * @param {browser.cookies.Cookie[]} cookies Cookies from the store
  * @param {string} storeId ID of the store
  */
-async function saveCookies(cookies, storeId) {  var header = [
+async function saveCookies(cookies, storeId) {
+  var header = [
     '# Netscape HTTP Cookie File\n',
     '# https://curl.haxx.se/rfc/cookie_spec.html\n',
     '# This is a generated file! Do not edit.\n\n'

--- a/background.js
+++ b/background.js
@@ -14,18 +14,25 @@ function formatCookie(co) {
   ].join('\t');
 }
 
+/**
+ * Get the cookies.txt file's name.
+ * @param {string} storeId ID of the cookie store to get cookies for.
+ */
 async function getCookiesFilename(storeId) {
+  console.log('Store ID', storeId);
   if (storeId == 'firefox-default') {
     return 'cookies.txt'
   } else {
-    let container;
+    let containerName;
     try {
-      container = await browser.contextualIdentities.get(storeId);
+      containerName = (await browser.contextualIdentities.get(storeId)).name;
     } catch (e) {
       /* In case we can't get the name of the container, fallback on the storeId */
-      container = storeId
+      containerName = storeId;
     }
-    return 'cookies.' + container.name + '.txt'
+    console.log('Store ID', storeId);
+    console.log('Container name', containerName);
+    return 'cookies.' + containerName + '.txt';
   }
 }
 

--- a/background.js
+++ b/background.js
@@ -33,14 +33,17 @@ async function getCookiesFilename(storeId) {
   }
 }
 
-async function saveCookies(cookies) {
-  var header = [
+/**
+ * Save all cookies from a given store.
+ * @param {browser.cookies.Cookie[]} cookies Cookies from the store
+ * @param {string} storeId ID of the store
+ */
+async function saveCookies(cookies, storeId) {  var header = [
     '# Netscape HTTP Cookie File\n',
     '# https://curl.haxx.se/rfc/cookie_spec.html\n',
     '# This is a generated file! Do not edit.\n\n'
   ];
   var body = cookies.map(formatCookie)
-  let storeId = cookies.length ? cookies[0].storeId : null;
   var blob = new Blob(header.concat(body), {type: 'text/plain'});
   var objectURL = URL.createObjectURL(blob);
   let cookiesFilename = await getCookiesFilename(storeId)
@@ -54,13 +57,13 @@ async function saveCookies(cookies) {
   );
 }
 
-function getCookies(stores_filter) {
+async function getCookies(stores_filter) {
   for (var store of stores_filter.stores) {
     console.log("Store: " + store.id)
-    var gettingAll = browser.cookies.getAll({
+    var cookies = await browser.cookies.getAll({
         ...stores_filter.filter,
         ...{ storeId: store.id, firstPartyDomain: null }});
-    gettingAll.then(saveCookies);
+    saveCookies(cookies, store.id);
   }
 }
 


### PR DESCRIPTION
Some changes to make sure no TypeErrors are thrown in case there are no cookies in a given store (which is quite possible if the user clicks on “Current Site” on a site where they don’t have any cookies).