### PR TITLE
Replace slash characters in resulting file names

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,7 +31,8 @@ async function getCookiesFilename(storeId) {
       /* In case we can't get the name of the container, fallback on the storeId */
       containerName = storeId;
     }
-    return 'cookies.' + containerName + '.txt';
+    let containerNameSafe = containerName.replaceAll(/[\/\\]/g, "_")
+    return 'cookies.' + containerNameSafe + '.txt';
   }
 }
 


### PR DESCRIPTION
On Firefox you can have arbitrarily named Containers and this extension supports separate export file per container. Naming scheme: "cookies.containerName.txt"

However when the container name contains a slash character, then the .download(...) function will automatically create a folder structure (unexpectedly).

For example, container name "Corp/Website" will ask the user to save that file in:

- Linux: /home/USER/Downloads/cookies.Corp/Website.txt
- Windows: L:/cookies.Corp/Website.txt (where L: is the last saved location)

Strip all slashes to prevent this. Other characters seem to be handled safely by the browser (like .. double-dot).

---

The slashes will be replaced with the `_` underscore.

**EDIT:** I have only tested this change in the JS console.