### PR TITLE
Buttons to download for current container only

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -14,5 +14,13 @@
   "popupSitesCurrent": {
     "message": "Aktuelle Website",
     "description": "Popup option text for exporting cookies only from the current site"
+  },
+  "popupSitesContainerAll": {
+    "message": "Current container",
+    "description": "Popup option text for exporting all cookies from the current container"
+  },
+  "popupSitesContainerCurrent": {
+    "message": "Current Site and container",
+    "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -16,11 +16,11 @@
     "description": "Popup option text for exporting cookies only from the current site"
   },
   "popupSitesContainerAll": {
-    "message": "Current container",
+    "message": "Current Container",
     "description": "Popup option text for exporting all cookies from the current container"
   },
   "popupSitesContainerCurrent": {
-    "message": "Current Site and container",
+    "message": "Current Container and Site",
     "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -16,11 +16,11 @@
     "description": "Popup option text for exporting cookies only from the current site"
   },
   "popupSitesContainerAll": {
-    "message": "Current container",
+    "message": "Current Container",
     "description": "Popup option text for exporting all cookies from the current container"
   },
   "popupSitesContainerCurrent": {
-    "message": "Current Site and container",
+    "message": "Current Container and Site",
     "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -14,5 +14,13 @@
   "popupSitesCurrent": {
     "message": "Τρέχων ιστότοπος",
     "description": "Popup option text for exporting cookies only from the current site"
+  },
+  "popupSitesContainerAll": {
+    "message": "Current container",
+    "description": "Popup option text for exporting all cookies from the current container"
+  },
+  "popupSitesContainerCurrent": {
+    "message": "Current Site and container",
+    "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -16,11 +16,11 @@
     "description": "Popup option text for exporting cookies only from the current site"
   },
   "popupSitesContainerAll": {
-    "message": "Current container",
+    "message": "Current Container",
     "description": "Popup option text for exporting all cookies from the current container"
   },
   "popupSitesContainerCurrent": {
-    "message": "Current Site and container",
+    "message": "Current Container and Site",
     "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -14,5 +14,13 @@
   "popupSitesCurrent": {
     "message": "Current Site",
     "description": "Popup option text for exporting cookies only from the current site"
+  },
+  "popupSitesContainerAll": {
+    "message": "Current container",
+    "description": "Popup option text for exporting all cookies from the current container"
+  },
+  "popupSitesContainerCurrent": {
+    "message": "Current Site and container",
+    "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -14,5 +14,13 @@
   "popupSitesCurrent": {
     "message": "現在のサイト",
     "description": "Popup option text for exporting cookies only from the current site"
+  },
+  "popupSitesContainerAll": {
+    "message": "Current container",
+    "description": "Popup option text for exporting all cookies from the current container"
+  },
+  "popupSitesContainerCurrent": {
+    "message": "Current Site and container",
+    "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -16,11 +16,11 @@
     "description": "Popup option text for exporting cookies only from the current site"
   },
   "popupSitesContainerAll": {
-    "message": "Current container",
+    "message": "Current Container",
     "description": "Popup option text for exporting all cookies from the current container"
   },
   "popupSitesContainerCurrent": {
-    "message": "Current Site and container",
+    "message": "Current Container and Site",
     "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -16,11 +16,11 @@
     "description": "Popup option text for exporting cookies only from the current site"
   },
   "popupSitesContainerAll": {
-    "message": "Current container",
+    "message": "Current Container",
     "description": "Popup option text for exporting all cookies from the current container"
   },
   "popupSitesContainerCurrent": {
-    "message": "Current Site and container",
+    "message": "Current Container and Site",
     "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -14,5 +14,13 @@
   "popupSitesCurrent": {
     "message": "От этого сайта",
     "description": "Popup option text for exporting cookies only from the current site"
+  },
+  "popupSitesContainerAll": {
+    "message": "Current container",
+    "description": "Popup option text for exporting all cookies from the current container"
+  },
+  "popupSitesContainerCurrent": {
+    "message": "Current Site and container",
+    "description": "Popup option text for exporting cookies only from the current site and current container"
   }
 }

--- a/background.js
+++ b/background.js
@@ -99,8 +99,15 @@ async function getCookies(stores_filter) {
 
 function handleClick(filter = {}) {
   browser.cookies.getAllCookieStores(stores =>
-      getCookies({stores: stores, filter: filter})
-    );
+      getCookies({
+        stores: stores.filter(store =>
+          // if cookieStoreId is not provided, do not filter
+          (filter.cookieStoreId == undefined) ||
+          // if cookieStoreId is provided, only provide that store
+          (store.id == filter.cookieStoreId)), 
+        filter: filter
+    })
+  );
 }
 
 browser.runtime.onMessage.addListener(handleClick)

--- a/background.js
+++ b/background.js
@@ -104,8 +104,8 @@ function handleClick(filter = {}) {
           // if cookieStoreId is not provided, do not filter
           (filter.cookieStoreId == undefined) ||
           // if cookieStoreId is provided, only provide that store
-          (store.id == filter.cookieStoreId)), 
-        filter: filter
+          (store.id == filter.cookieStoreId)),
+        filter: {url: filter.url}
     })
   );
 }

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -9,6 +9,8 @@
     <div id="popup-content">
       <button class="all" data-i18n="popupSitesAll"></button>
       <button class="current" data-i18n="popupSitesCurrent"></button>
+      <button class="container-all" data-i18n="popupSitesContainerAll"></button>
+      <button class="container-current" data-i18n="popupSitesContainerCurrent"></button>
     </div>
     <script src="choose_option.js"></script>
   </body>

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -7,9 +7,9 @@
   </head>
   <body>
     <div id="popup-content">
-      <button class="all" data-i18n="popupSitesAll"></button>
-      <button class="current" data-i18n="popupSitesCurrent"></button>
-      <button class="container-all" data-i18n="popupSitesContainerAll"></button>
+      <button class="all" data-i18n="popupSitesAll"></button><br>
+      <button class="current" data-i18n="popupSitesCurrent"></button><br>
+      <button class="container-all" data-i18n="popupSitesContainerAll"></button><br>
       <button class="container-current" data-i18n="popupSitesContainerCurrent"></button>
     </div>
     <script src="choose_option.js"></script>

--- a/popup/choose_option.js
+++ b/popup/choose_option.js
@@ -18,3 +18,23 @@ document.querySelector(".current").addEventListener("click", () => {
       });
   window.close();
 });
+document.querySelector(".container-all").addEventListener("click", () => {
+  var query = (typeof browser === "undefined") ? {active: true, windowId : browser.windows.WINDOW_ID_CURRENT}
+    :  {active: true, currentWindow: true};
+  browser.tabs.query(query, tabs => {
+        if (tabs.length > 0) {
+          browser.runtime.sendMessage({cookieStoreId: tabs[0].cookieStoreId});
+        }
+      });
+  window.close();
+});
+document.querySelector(".container-current").addEventListener("click", () => {
+  var query = (typeof browser === "undefined") ? {active: true, windowId : browser.windows.WINDOW_ID_CURRENT}
+    :  {active: true, currentWindow: true};
+  browser.tabs.query(query, tabs => {
+        if (tabs.length > 0) {
+          browser.runtime.sendMessage({url: tabs[0].url, cookieStoreId: tabs[0].cookieStoreId});
+        }
+      });
+  window.close();
+});


### PR DESCRIPTION
This PR adds two new buttons:
- Current Container
- Current Container and Site

which download cookies from the current container only when clicked.

![Screenshot 2024-10-02 094039](https://github.com/user-attachments/assets/0d248b34-1e5d-4eff-be13-4db5dba58b99)


I have not attempted translations for languages other than English, for now I just copied the English text over.

Closes #26 