### PR TITLE
hotfix fractional expirationDate (FF 142+)

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,7 +10,7 @@ function formatCookie(co) {
     co.hostOnly ? 'FALSE' : 'TRUE',
     co.path,
     co.secure ? 'TRUE' : 'FALSE',
-    co.session || !co.expirationDate ? 0 : co.expirationDate,
+    co.session || !co.expirationDate ? 0 : Math.floor(co.expirationDate),
     co.name,
     co.value + '\n'
   ].join('\t');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1986688

Firefox starting sometime in v142 changed how cookies are stored (now in milliseconds) and this leaked through all the APIs and began to return fractional values for expiration dates.

The expiry time was supposed to always be in seconds (UNIX timestamp), so it broke cookie.txt output (contains fraction) that is obviously being refused by reading programs.

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie#expirationdate

PS:

> WARNING: skipping cookie file entry due to invalid expires at 1791464381.742: '.website.example\tTRUE\t/\tTRUE\t1791464381.742\tPREF\t ......'