### PR TITLE
Implemented feature for dumping cookes to the clipboard

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -7,6 +7,14 @@
     "message": "Cookies exportieren",
     "description": "Tooltip of the browser toolbar icon."
   },
+  "copyBtn": {
+    "message": "Copy",
+    "description": "Copy button that appears next to all titles listed below"
+  },
+  "downloadBtn": {
+    "message": "Download",
+    "description": "Download button that appears next to all titles listed below"
+  },
   "popupSitesAll": {
     "message": "Alle",
     "description": "Popup option text for exporting all cookies"

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -11,10 +11,6 @@
     "message": "Alle",
     "description": "Popup option text for exporting all cookies"
   },
-  "popupSitesAllClipboard": {
-    "message": "ALL (copy to clipboard)",
-    "description": "Popup option text for exporting all cookies to the clipboard"
-  },
   "popupSitesCurrent": {
     "message": "Aktuelle Website",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -11,6 +11,10 @@
     "message": "Alle",
     "description": "Popup option text for exporting all cookies"
   },
+  "popupSitesAllClipboard": {
+    "message": "ALL (copy to clipboard)",
+    "description": "Popup option text for exporting all cookies to the clipboard"
+  },
   "popupSitesCurrent": {
     "message": "Aktuelle Website",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -7,6 +7,14 @@
     "message": "Εξαγωγή cookies",
     "description": "Tooltip of the browser toolbar icon."
   },
+  "copyBtn": {
+    "message": "Copy",
+    "description": "Copy button that appears next to all titles listed below"
+  },
+  "downloadBtn": {
+    "message": "Download",
+    "description": "Download button that appears next to all titles listed below"
+  },
   "popupSitesAll": {
     "message": "Όλα",
     "description": "Popup option text for exporting all cookies"

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -11,6 +11,10 @@
     "message": "Όλα",
     "description": "Popup option text for exporting all cookies"
   },
+  "popupSitesAllClipboard": {
+    "message": "ALL (copy to clipboard)",
+    "description": "Popup option text for exporting all cookies to the clipboard"
+  },
   "popupSitesCurrent": {
     "message": "Τρέχων ιστότοπος",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -11,10 +11,6 @@
     "message": "Όλα",
     "description": "Popup option text for exporting all cookies"
   },
-  "popupSitesAllClipboard": {
-    "message": "ALL (copy to clipboard)",
-    "description": "Popup option text for exporting all cookies to the clipboard"
-  },
   "popupSitesCurrent": {
     "message": "Τρέχων ιστότοπος",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -7,6 +7,14 @@
     "message": "Export cookies",
     "description": "Tooltip of the browser toolbar icon."
   },
+  "copyBtn": {
+    "message": "Copy",
+    "description": "Copy button that appears next to all titles listed below"
+  },
+  "downloadBtn": {
+    "message": "Download",
+    "description": "Download button that appears next to all titles listed below"
+  },
   "popupSitesAll": {
     "message": "ALL",
     "description": "Popup option text for exporting all cookies"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -11,6 +11,10 @@
     "message": "ALL",
     "description": "Popup option text for exporting all cookies"
   },
+  "popupSitesAllClipboard": {
+    "message": "ALL (copy to clipboard)",
+    "description": "Popup option text for exporting all cookies to the clipboard"
+  },
   "popupSitesCurrent": {
     "message": "Current Site",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -19,10 +19,6 @@
     "message": "ALL",
     "description": "Popup option text for exporting all cookies"
   },
-  "popupSitesAllClipboard": {
-    "message": "ALL (copy to clipboard)",
-    "description": "Popup option text for exporting all cookies to the clipboard"
-  },
   "popupSitesCurrent": {
     "message": "Current Site",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -7,6 +7,14 @@
     "message": "Sütik exportálása",
     "description": "Tooltip of the browser toolbar icon."
   },
+  "copyBtn": {
+    "message": "Másolás",
+    "description": "Copy button that appears next to all titles listed below"
+  },
+  "downloadBtn": {
+    "message": "Letöltés",
+    "description": "Download button that appears next to all titles listed below"
+  },
   "popupSitesAll": {
     "message": "Összes",
     "description": "Popup option text for exporting all cookies"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -7,6 +7,14 @@
     "message": "クッキーを出力する",
     "description": "Tooltip of the browser toolbar icon."
   },
+  "copyBtn": {
+    "message": "Copy",
+    "description": "Copy button that appears next to all titles listed below"
+  },
+  "downloadBtn": {
+    "message": "Download",
+    "description": "Download button that appears next to all titles listed below"
+  },
   "popupSitesAll": {
     "message": "全てのサイト",
     "description": "Popup option text for exporting all cookies"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -11,6 +11,10 @@
     "message": "全てのサイト",
     "description": "Popup option text for exporting all cookies"
   },
+  "popupSitesAllClipboard": {
+    "message": "ALL (copy to clipboard)",
+    "description": "Popup option text for exporting all cookies to the clipboard"
+  },
   "popupSitesCurrent": {
     "message": "現在のサイト",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -11,10 +11,6 @@
     "message": "全てのサイト",
     "description": "Popup option text for exporting all cookies"
   },
-  "popupSitesAllClipboard": {
-    "message": "ALL (copy to clipboard)",
-    "description": "Popup option text for exporting all cookies to the clipboard"
-  },
   "popupSitesCurrent": {
     "message": "現在のサイト",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -7,6 +7,14 @@
     "message": "Экспортировать куки",
     "description": "Tooltip of the browser toolbar icon."
   },
+  "copyBtn": {
+    "message": "Copy",
+    "description": "Copy button that appears next to all titles listed below"
+  },
+  "downloadBtn": {
+    "message": "Download",
+    "description": "Download button that appears next to all titles listed below"
+  },
   "popupSitesAll": {
     "message": "ВСЕ",
     "description": "Popup option text for exporting all cookies"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -11,6 +11,10 @@
     "message": "ВСЕ",
     "description": "Popup option text for exporting all cookies"
   },
+  "popupSitesAllClipboard": {
+    "message": "ALL (copy to clipboard)",
+    "description": "Popup option text for exporting all cookies to the clipboard"
+  },
   "popupSitesCurrent": {
     "message": "От этого сайта",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -11,10 +11,6 @@
     "message": "ВСЕ",
     "description": "Popup option text for exporting all cookies"
   },
-  "popupSitesAllClipboard": {
-    "message": "ALL (copy to clipboard)",
-    "description": "Popup option text for exporting all cookies to the clipboard"
-  },
   "popupSitesCurrent": {
     "message": "От этого сайта",
     "description": "Popup option text for exporting cookies only from the current site"

--- a/background.js
+++ b/background.js
@@ -40,67 +40,84 @@ async function getCookiesFilename(storeId) {
  * Save all cookies from a given store.
  * @param {browser.cookies.Cookie[]} cookies Cookies from the store
  * @param {string} storeId ID of the store
+ * @param {boolean} clipboard whether to copy to clipboard instead of download
  */
-async function saveCookies(cookies, storeId) {
+async function saveCookies(cookies, storeId, clipboard = false) {
   var header = [
     '# Netscape HTTP Cookie File\n',
     '# https://curl.haxx.se/rfc/cookie_spec.html\n',
     '# This is a generated file! Do not edit.\n\n'
   ];
   var body = cookies.map(formatCookie)
-  var blob = new Blob(header.concat(body), {type: 'text/plain'});
-  let cookiesFilename = await getCookiesFilename(storeId);
-  // browser.downloads is not supported yet and fails silently
-  if ((await browser.runtime.getPlatformInfo()).os == "android") {
-    const tabId = (await browser.tabs.query({active: true, currentWindow: true}))[0].id;
+
+  if (clipboard) {
+    const text = header.concat(body).join('');
+    const tabId = (await browser.tabs.query({ active: true, currentWindow: true }))[0].id;
     await browser.tabs.sendMessage(tabId, {
-      message: "Download",
-      blob: blob,
-      filename: cookiesFilename
+      message: "Clipboard",
+      text: text
     });
   } else {
-    const objectURL = URL.createObjectURL(blob);
-    browser.downloads.download(
-      {
-        url: objectURL,
-        filename: cookiesFilename,
-        saveAs: true,
-        conflictAction: 'overwrite'
-      }
-    );
+    var blob = new Blob(header.concat(body), { type: 'text/plain' });
+    let cookiesFilename = await getCookiesFilename(storeId);
+    // browser.downloads is not supported yet and fails silently
+    if ((await browser.runtime.getPlatformInfo()).os == "android") {
+      const tabId = (await browser.tabs.query({ active: true, currentWindow: true }))[0].id;
+      await browser.tabs.sendMessage(tabId, {
+        message: "Download",
+        blob: blob,
+        filename: cookiesFilename
+      });
+    } else {
+      const objectURL = URL.createObjectURL(blob);
+      browser.downloads.download(
+        {
+          url: objectURL,
+          filename: cookiesFilename,
+          saveAs: true,
+          conflictAction: 'overwrite'
+        }
+      );
+    }
   }
 }
 
-async function getCookies(stores_filter) {
+async function getCookies(stores_filter, clipboard = false) {
   for (var store of stores_filter.stores) {
     try {
-      query = { ...stores_filter.filter, ...{ storeId: store.id,
-        firstPartyDomain: null } };
+      query = {
+        ...stores_filter.filter, ...{
+          storeId: store.id,
+          firstPartyDomain: null
+        }
+      };
       cookies = await browser.cookies.getAll(query);
-      await saveCookies(cookies, store.id);
-    } catch(e) {
+      await saveCookies(cookies, store.id, clipboard);
+    } catch (e) {
       /* Returning a promise when no function is specified has not been implemented:
        * https://developer.chrome.com/docs/extensions/reference/cookies/#method-getAll */
       cookies = await browser.cookies.getAll(
-        { ...stores_filter.filter,
+        {
+          ...stores_filter.filter,
           ...{ storeId: store.id }
         },
-        cookies => saveCookies(cookies, store.id)
+        cookies => saveCookies(cookies, store.id, clipboard)
       );
     }
   }
 }
 
 function handleClick(filter = {}) {
+  const clipboard = filter.clipboard || false;
   browser.cookies.getAllCookieStores(stores =>
-      getCookies({
-        stores: stores.filter(store =>
-          // if cookieStoreId is not provided, do not filter
-          (filter.cookieStoreId == undefined) ||
-          // if cookieStoreId is provided, only provide that store
-          (store.id == filter.cookieStoreId)),
-        filter: {url: filter.url}
-    })
+    getCookies({
+      stores: stores.filter(store =>
+        // if cookieStoreId is not provided, do not filter
+        (filter.cookieStoreId == undefined) ||
+        // if cookieStoreId is provided, only provide that store
+        (store.id == filter.cookieStoreId)),
+      filter: { url: filter.url }
+    }, clipboard)
   );
 }
 

--- a/content.js
+++ b/content.js
@@ -12,6 +12,8 @@ async function download(filename, blob) {
 async function onMessage(message, sender, sendResponse) {
   if (message.message == "Download") {
     download(message.filename, message.blob);
+  } else if (message.message == "Clipboard") {
+    await navigator.clipboard.writeText(message.text);
   }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -53,6 +53,7 @@
     "downloads",
     "contextualIdentities",
     "<all_urls>",
-    "tabs"
+    "tabs",
+    "clipboardWrite"
   ]
 }

--- a/popup/choose_option.css
+++ b/popup/choose_option.css
@@ -1,14 +1,40 @@
-button {
-  width: 100%;
-  margin: 3% auto;
-  border: none;
-  padding: 4px;
-  background: none;
-  text-align: center;
-  font-size: 0.75em;
-  cursor: pointer;
+.option-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 3% auto;
+    padding: 4px;
 }
 
-button:hover {
-  background-color: khaki;
+.option-text {
+    flex: 1;
+    border: none;
+    padding: 0;
+    background: none;
+    text-align: left;
+    font-size: 0.75em;
+    cursor: pointer;
+}
+
+.action-buttons {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.action-btn {
+    border: none;
+    padding: 2px 6px;
+    background: none;
+    font-size: 0.7em;
+    cursor: pointer;
+}
+
+.action-btn:hover {
+    background-color: khaki;
+}
+
+.separator {
+    font-size: 0.7em;
+    color: #666;
 }

--- a/popup/choose_option.css
+++ b/popup/choose_option.css
@@ -8,12 +8,11 @@
 
 .option-text {
     flex: 1;
-    border: none;
+    margin: 0;
     padding: 0;
-    background: none;
     text-align: left;
+    font-family: Arial, Helvetica, sans-serif;
     font-size: 0.75em;
-    cursor: pointer;
 }
 
 .action-buttons {

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -10,33 +10,33 @@
       <div id="all" class="option-row">
         <p class="option-text" data-i18n="popupSitesAll"></p>
         <div class="action-buttons">
-          <button class="copy action-btn">Copy</button>
+          <button class="copy action-btn" data-i18n="copyBtn"></button>
           <span class="separator">|</span>
-          <button class="download action-btn">Download</button>
+          <button class="download action-btn" data-i18n="downloadBtn"></button>
         </div>
       </div>
       <div id="current" class="option-row">
         <p class="option-text" data-i18n="popupSitesCurrent"></p>
         <div class="action-buttons">
-          <button class="copy action-btn">Copy</button>
+          <button class="copy action-btn" data-i18n="copyBtn"></button>
           <span class="separator">|</span>
-          <button class="download action-btn">Download</button>
+          <button class="download action-btn" data-i18n="downloadBtn"></button>
         </div>
       </div>
       <div id="container-all" class="option-row">
         <p class="option-text" data-i18n="popupSitesContainerAll"></p>
         <div class="action-buttons">
-          <button class="copy action-btn">Copy</button>
+          <button class="copy action-btn" data-i18n="copyBtn"></button>
           <span class="separator">|</span>
-          <button class="download action-btn">Download</button>
+          <button class="download action-btn" data-i18n="downloadBtn"></button>
         </div>
       </div>
       <div id="container-current" class="option-row">
         <p class="option-text" data-i18n="popupSitesContainerCurrent"></p>
         <div class="action-buttons">
-          <button class="copy action-btn">Copy</button>
+          <button class="copy action-btn" data-i18n="copyBtn"></button>
           <span class="separator">|</span>
-          <button class="download action-btn">Download</button>
+          <button class="download action-btn" data-i18n="downloadBtn"></button>
         </div>
       </div>
     </div>

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -8,6 +8,7 @@
   <body>
     <div id="popup-content">
       <button class="all" data-i18n="popupSitesAll"></button><br>
+      <button class="all-clipboard" data-i18n="popupSitesAllClipboard"></button><br>
       <button class="current" data-i18n="popupSitesCurrent"></button><br>
       <button class="container-all" data-i18n="popupSitesContainerAll"></button><br>
       <button class="container-current" data-i18n="popupSitesContainerCurrent"></button>

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -10,33 +10,33 @@
       <div id="all" class="option-row">
         <p class="option-text" data-i18n="popupSitesAll"></p>
         <div class="action-buttons">
-          <button class="action-btn">Copy</button>
+          <button class="copy action-btn">Copy</button>
           <span class="separator">|</span>
-          <button class="action-btn">Download</button>
+          <button class="download action-btn">Download</button>
         </div>
       </div>
       <div id="current" class="option-row">
         <p class="option-text" data-i18n="popupSitesCurrent"></p>
         <div class="action-buttons">
-          <button class="action-btn">Copy</button>
+          <button class="copy action-btn">Copy</button>
           <span class="separator">|</span>
-          <button class="action-btn">Download</button>
+          <button class="download action-btn">Download</button>
         </div>
       </div>
       <div id="container-all" class="option-row">
         <p class="option-text" data-i18n="popupSitesContainerAll"></p>
         <div class="action-buttons">
-          <button class="action-btn">Copy</button>
+          <button class="copy action-btn">Copy</button>
           <span class="separator">|</span>
-          <button class="action-btn">Download</button>
+          <button class="download action-btn">Download</button>
         </div>
       </div>
       <div id="container-current" class="option-row">
         <p class="option-text" data-i18n="popupSitesContainerCurrent"></p>
         <div class="action-buttons">
-          <button class="action-btn">Copy</button>
+          <button class="copy action-btn">Copy</button>
           <span class="separator">|</span>
-          <button class="action-btn">Download</button>
+          <button class="download action-btn">Download</button>
         </div>
       </div>
     </div>

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -7,32 +7,32 @@
   </head>
   <body>
     <div id="popup-content">
-      <div class="option-row">
-        <button class="all option-text" data-i18n="popupSitesAll"></button>
+      <div id="all" class="option-row">
+        <p class="option-text" data-i18n="popupSitesAll"></p>
         <div class="action-buttons">
           <button class="action-btn">Copy</button>
           <span class="separator">|</span>
           <button class="action-btn">Download</button>
         </div>
       </div>
-      <div class="option-row">
-        <button class="current option-text" data-i18n="popupSitesCurrent"></button>
+      <div id="current" class="option-row">
+        <p class="option-text" data-i18n="popupSitesCurrent"></p>
         <div class="action-buttons">
           <button class="action-btn">Copy</button>
           <span class="separator">|</span>
           <button class="action-btn">Download</button>
         </div>
       </div>
-      <div class="option-row">
-        <button class="container-all option-text" data-i18n="popupSitesContainerAll"></button>
+      <div id="container-all" class="option-row">
+        <p class="option-text" data-i18n="popupSitesContainerAll"></p>
         <div class="action-buttons">
           <button class="action-btn">Copy</button>
           <span class="separator">|</span>
           <button class="action-btn">Download</button>
         </div>
       </div>
-      <div class="option-row">
-        <button class="container-current option-text" data-i18n="popupSitesContainerCurrent"></button>
+      <div id="container-current" class="option-row">
+        <p class="option-text" data-i18n="popupSitesContainerCurrent"></p>
         <div class="action-buttons">
           <button class="action-btn">Copy</button>
           <span class="separator">|</span>

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -16,14 +16,6 @@
         </div>
       </div>
       <div class="option-row">
-        <button class="all-clipboard option-text" data-i18n="popupSitesAllClipboard"></button>
-        <div class="action-buttons">
-          <button class="action-btn">Copy</button>
-          <span class="separator">|</span>
-          <button class="action-btn">Download</button>
-        </div>
-      </div>
-      <div class="option-row">
         <button class="current option-text" data-i18n="popupSitesCurrent"></button>
         <div class="action-buttons">
           <button class="action-btn">Copy</button>

--- a/popup/choose_option.html
+++ b/popup/choose_option.html
@@ -7,11 +7,46 @@
   </head>
   <body>
     <div id="popup-content">
-      <button class="all" data-i18n="popupSitesAll"></button><br>
-      <button class="all-clipboard" data-i18n="popupSitesAllClipboard"></button><br>
-      <button class="current" data-i18n="popupSitesCurrent"></button><br>
-      <button class="container-all" data-i18n="popupSitesContainerAll"></button><br>
-      <button class="container-current" data-i18n="popupSitesContainerCurrent"></button>
+      <div class="option-row">
+        <button class="all option-text" data-i18n="popupSitesAll"></button>
+        <div class="action-buttons">
+          <button class="action-btn">Copy</button>
+          <span class="separator">|</span>
+          <button class="action-btn">Download</button>
+        </div>
+      </div>
+      <div class="option-row">
+        <button class="all-clipboard option-text" data-i18n="popupSitesAllClipboard"></button>
+        <div class="action-buttons">
+          <button class="action-btn">Copy</button>
+          <span class="separator">|</span>
+          <button class="action-btn">Download</button>
+        </div>
+      </div>
+      <div class="option-row">
+        <button class="current option-text" data-i18n="popupSitesCurrent"></button>
+        <div class="action-buttons">
+          <button class="action-btn">Copy</button>
+          <span class="separator">|</span>
+          <button class="action-btn">Download</button>
+        </div>
+      </div>
+      <div class="option-row">
+        <button class="container-all option-text" data-i18n="popupSitesContainerAll"></button>
+        <div class="action-buttons">
+          <button class="action-btn">Copy</button>
+          <span class="separator">|</span>
+          <button class="action-btn">Download</button>
+        </div>
+      </div>
+      <div class="option-row">
+        <button class="container-current option-text" data-i18n="popupSitesContainerCurrent"></button>
+        <div class="action-buttons">
+          <button class="action-btn">Copy</button>
+          <span class="separator">|</span>
+          <button class="action-btn">Download</button>
+        </div>
+      </div>
     </div>
     <script src="choose_option.js"></script>
   </body>

--- a/popup/choose_option.js
+++ b/popup/choose_option.js
@@ -15,14 +15,17 @@ queryWithCurrentTab = (tabToMsgFn) => {
   window.close();
 };
 
+//download buttons
 document.querySelector("#all .download").addEventListener("click", () => {
   browser.runtime.sendMessage({});
-  window.close();
-});
-document.querySelector("#all-clipboard .download").addEventListener("click", () => {
-  browser.runtime.sendMessage({ clipboard: true });
   window.close();
 });
 document.querySelector("#current .download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
 document.querySelector("#container-all .download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
 document.querySelector("#container-current .download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));
+
+//copy buttons
+document.querySelector("#all .copy").addEventListener("click", () => {
+  browser.runtime.sendMessage({ clipboard: true });
+  window.close();
+});

--- a/popup/choose_option.js
+++ b/popup/choose_option.js
@@ -29,3 +29,6 @@ document.querySelector("#all .copy").addEventListener("click", () => {
   browser.runtime.sendMessage({ clipboard: true });
   window.close();
 });
+document.querySelector("#current .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
+document.querySelector("#container-all .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
+document.querySelector("#container-current .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));

--- a/popup/choose_option.js
+++ b/popup/choose_option.js
@@ -29,6 +29,6 @@ document.querySelector("#all .copy").addEventListener("click", () => {
   browser.runtime.sendMessage({ clipboard: true });
   window.close();
 });
-document.querySelector("#current .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
-document.querySelector("#container-all .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
-document.querySelector("#container-current .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));
+document.querySelector("#current .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, clipboard: true })));
+document.querySelector("#container-all .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId, clipboard: true })));
+document.querySelector("#container-current .copy").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId, clipboard: true })));

--- a/popup/choose_option.js
+++ b/popup/choose_option.js
@@ -15,14 +15,14 @@ queryWithCurrentTab = (tabToMsgFn) => {
   window.close();
 };
 
-document.querySelector(".all").addEventListener("click", () => {
+document.querySelector("#all download").addEventListener("click", () => {
   browser.runtime.sendMessage({});
   window.close();
 });
-document.querySelector(".all-clipboard").addEventListener("click", () => {
+document.querySelector("#all-clipboard download").addEventListener("click", () => {
   browser.runtime.sendMessage({ clipboard: true });
   window.close();
 });
-document.querySelector(".current").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
-document.querySelector(".container-all").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
-document.querySelector(".container-current").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));
+document.querySelector("#current download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
+document.querySelector("#container-all download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
+document.querySelector("#container-current download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));

--- a/popup/choose_option.js
+++ b/popup/choose_option.js
@@ -5,13 +5,13 @@ for (const elem of document.querySelectorAll("[data-i18n]")) {
 }
 
 queryWithCurrentTab = (tabToMsgFn) => {
-  var query = (typeof browser === "undefined") ? {active: true, windowId : browser.windows.WINDOW_ID_CURRENT}
-    :  {active: true, currentWindow: true};
+  var query = (typeof browser === "undefined") ? { active: true, windowId: browser.windows.WINDOW_ID_CURRENT }
+    : { active: true, currentWindow: true };
   browser.tabs.query(query, tabs => {
-        if (tabs.length > 0) {
-          browser.runtime.sendMessage(tabToMsgFn(tabs[0]));
-        }
-      });
+    if (tabs.length > 0) {
+      browser.runtime.sendMessage(tabToMsgFn(tabs[0]));
+    }
+  });
   window.close();
 };
 
@@ -19,6 +19,10 @@ document.querySelector(".all").addEventListener("click", () => {
   browser.runtime.sendMessage({});
   window.close();
 });
-document.querySelector(".current").addEventListener("click", () => queryWithCurrentTab((tab) => ({url: tab.url})));
-document.querySelector(".container-all").addEventListener("click", () => queryWithCurrentTab((tab) => ({cookieStoreId: tab.cookieStoreId})));
-document.querySelector(".container-current").addEventListener("click", () => queryWithCurrentTab((tab) => ({url: tab.url, cookieStoreId: tab.cookieStoreId})));
+document.querySelector(".all-clipboard").addEventListener("click", () => {
+  browser.runtime.sendMessage({ clipboard: true });
+  window.close();
+});
+document.querySelector(".current").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
+document.querySelector(".container-all").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
+document.querySelector(".container-current").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));

--- a/popup/choose_option.js
+++ b/popup/choose_option.js
@@ -15,14 +15,14 @@ queryWithCurrentTab = (tabToMsgFn) => {
   window.close();
 };
 
-document.querySelector("#all download").addEventListener("click", () => {
+document.querySelector("#all .download").addEventListener("click", () => {
   browser.runtime.sendMessage({});
   window.close();
 });
-document.querySelector("#all-clipboard download").addEventListener("click", () => {
+document.querySelector("#all-clipboard .download").addEventListener("click", () => {
   browser.runtime.sendMessage({ clipboard: true });
   window.close();
 });
-document.querySelector("#current download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
-document.querySelector("#container-all download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
-document.querySelector("#container-current download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));
+document.querySelector("#current .download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url })));
+document.querySelector("#container-all .download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ cookieStoreId: tab.cookieStoreId })));
+document.querySelector("#container-current .download").addEventListener("click", () => queryWithCurrentTab((tab) => ({ url: tab.url, cookieStoreId: tab.cookieStoreId })));


### PR DESCRIPTION
Changes:

- Added an **_ALL (copy to clipboard)_** button to the options
- Updated all existing `_locales` with the new object
- Added corresponding `.addEventListener` function & action for handling the copy action
- Modified the `saveCookies()` function to handle copying
- Included `clipboardWrite` permission in `manifest.json`

Tested in:

- Firefox
- LibreWolf

**If needed, I can also split the buttons into 2 columns, so each cookie scope can be copied to the clipboard / exported as a file.**

<hr>

Edits after comment:

- Added a **copyBtn** & **downloadBtn** next to each scope for complete coverage
- Updated locales with the new button texts
- Updated / added some query selectors to pass `clipboard: true` when needed

Resolves #23